### PR TITLE
Sbt multi-module config clean up

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import play.sbt.PlayJava
 import play.sbt.routes.RoutesKeys._
-import sbt.Keys._
+import sbt.Keys.{publishTo, _}
 
 scalaVersion in Global := "2.11.7"
 
@@ -8,7 +8,7 @@ def ProjectName(name: String,path:String): Project =  Project(name, file(path))
 
 organization := "br.ufes.inf.lprm"
 name := "scene-platform"
-version := "2.0.0"
+version := "1.0.0"
 
 libraryDependencies in Global ++= Seq()
 
@@ -27,21 +27,39 @@ val `org.slf4j_slf4j-api` = "org.slf4j" % "slf4j-api" % "1.7.21"
 val `org.reflections_reflections` = "org.reflections" % "reflections" % "0.9.10"
 
 lazy val `situation-model` = ProjectName("situation-model","situation-model").settings(
+
+  crossPaths := false,
+
   libraryDependencies ++= Seq(`joda-time_joda-time`),
-    name := "situation-model",
-    version := "2.0.0",
-    organization := "br.ufes.inf.lprm"
-).settings().dependsOn()
+
+  name := "situation-model",
+  version := "1.0.0",
+  organization := "br.ufes.inf.lprm",
+
+  publishTo := Some("My Maven Repo" at "https://mymavenrepo.com/repo/PkZASKyCrrcPaIvQ1RtQ/")
+
+).dependsOn()
 
 lazy val `scene-examples` = ProjectName("scene-examples","scene-examples").settings(
+
+  crossPaths := false,
+
   libraryDependencies ++= Seq(),
     name := "scene-examples",
-    version := "2.0.0",
+    version := "1.0.0",
     organization := "br.ufes.inf.lprm"
 ).settings().dependsOn(`scene-core`)
 
-lazy val `scene-core` = ProjectName("scene-core","scene-core").settings(
-  libraryDependencies ++= Seq(`org.slf4j_slf4j-log4j12`,
+lazy val `scene-core` = ProjectName("scene-core","scene-core")
+  .settings(
+
+    name := "scene-core",
+    version := "1.0.0",
+    organization := "br.ufes.inf.lprm",
+
+    crossPaths := false,
+
+    libraryDependencies ++= Seq(`org.slf4j_slf4j-log4j12`,
    `org.slf4j_slf4j-api`,
    `org.kie_kie-api`,
    `org.drools_drools-core`,
@@ -50,19 +68,24 @@ lazy val `scene-core` = ProjectName("scene-core","scene-core").settings(
     `joda-time_joda-time`,
     `com.google.code.gson_gson`,
     `org.reflections_reflections`),
-    name := "scene-core",
-    version := "2.0.0",
-    organization := "br.ufes.inf.lprm"
-).settings().dependsOn(`situation-model`)
+
+    publishTo := Some("My Maven Repo" at "https://mymavenrepo.com/repo/PkZASKyCrrcPaIvQ1RtQ/")
+
+  ).dependsOn(`situation-model`)
 
 lazy val `scene-server` = ProjectName("scene-server","scene-server")
   .enablePlugins(PlayJava)
   .disablePlugins(PlayLogback)
   .settings(
-    libraryDependencies ++= Seq(javaCore, filters),
+
     name := "scene-server",
-    version := "2.0.0",
+    version := "1.0.0",
     organization := "br.ufes.inf.lprm",
+
+    crossPaths := false,
+
+    libraryDependencies ++= Seq(javaCore, filters),
+
     routesGenerator := InjectedRoutesGenerator
-  ).settings().dependsOn(`scene-core`)
+  ).dependsOn(`scene-core`)
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,90 +2,42 @@ import play.sbt.PlayJava
 import play.sbt.routes.RoutesKeys._
 import sbt.Keys.{publishTo, _}
 
-scalaVersion in Global := "2.11.7"
-
-def ProjectName(name: String,path:String): Project =  Project(name, file(path))
+//scalaVersion in Global := "2.11.7"
 
 organization := "br.ufes.inf.lprm"
-name := "scene-platform"
+name := SceneBuild.ProjectPrefix + "platform"
 version := "1.0.0"
 
-libraryDependencies in Global ++= Seq()
+def ProjectDef(name: String, v: String): Project =  Project(name, file(name)).settings(version := v)
 
 resolvers in Global ++= Seq(Resolver.mavenLocal,
                             "jboss" at "http://repository.jboss.org/nexus/content/groups/public/" ,
                             "repo1" at "http://repo1.maven.org/maven2/" )
 
-val `com.google.code.gson_gson` = "com.google.code.gson" % "gson" % "2.7"
-val `joda-time_joda-time` = "joda-time" % "joda-time" % "2.3"
-val `junit_junit` = "junit" % "junit" % "4.8.1"
-val `org.drools_drools-compiler` = "org.drools" % "drools-compiler" % "6.5.0.Final"
-val `org.drools_drools-core` = "org.drools" % "drools-core" % "6.5.0.Final"
-val `org.kie_kie-api` = "org.kie" % "kie-api" % "6.5.0.Final"
-val `org.slf4j_slf4j-log4j12` = "org.slf4j" % "slf4j-log4j12" % "1.7.21"
-val `org.slf4j_slf4j-api` = "org.slf4j" % "slf4j-api" % "1.7.21"
-val `org.reflections_reflections` = "org.reflections" % "reflections" % "0.9.10"
+lazy val model = ProjectDef("situation-model", "1.0.0").
+                    settings(Common.settings: _*).
+                    settings(
+                      libraryDependencies ++= Dependencies.modelDependencies,
+                      publishTo := Common.mavenRepo
+                    ).dependsOn()
 
-lazy val `situation-model` = ProjectName("situation-model","situation-model").settings(
+lazy val core = ProjectDef("scene-core", "1.1.0")
+                        .settings(Common.settings: _*)
+                        .settings(
+                          libraryDependencies ++= Dependencies.coreDependencies,
+                          isSnapshot := true,
+                          publishTo := Common.mavenRepo
+                        ).dependsOn(model)
 
-  crossPaths := false,
+lazy val examples = ProjectDef("scene-examples", "1.0.0")
+                      .settings(Common.settings: _*)
+                      .dependsOn(core)
 
-  libraryDependencies ++= Seq(`joda-time_joda-time`),
-
-  name := "situation-model",
-  version := "1.0.0",
-  organization := "br.ufes.inf.lprm",
-
-  publishTo := Some("My Maven Repo" at "https://mymavenrepo.com/repo/PkZASKyCrrcPaIvQ1RtQ/")
-
-).dependsOn()
-
-lazy val `scene-examples` = ProjectName("scene-examples","scene-examples").settings(
-
-  crossPaths := false,
-
-  libraryDependencies ++= Seq(),
-    name := "scene-examples",
-    version := "1.0.0",
-    organization := "br.ufes.inf.lprm"
-).settings().dependsOn(`scene-core`)
-
-lazy val `scene-core` = ProjectName("scene-core","scene-core")
-  .settings(
-
-    name := "scene-core",
-    version := "1.0.0",
-    organization := "br.ufes.inf.lprm",
-
-    crossPaths := false,
-
-    libraryDependencies ++= Seq(`org.slf4j_slf4j-log4j12`,
-   `org.slf4j_slf4j-api`,
-   `org.kie_kie-api`,
-   `org.drools_drools-core`,
-   `junit_junit`,
-   `org.drools_drools-compiler`,
-    `joda-time_joda-time`,
-    `com.google.code.gson_gson`,
-    `org.reflections_reflections`),
-
-    publishTo := Some("My Maven Repo" at "https://mymavenrepo.com/repo/PkZASKyCrrcPaIvQ1RtQ/")
-
-  ).dependsOn(`situation-model`)
-
-lazy val `scene-server` = ProjectName("scene-server","scene-server")
+lazy val server = ProjectDef("scene-server", "1.0.0")
   .enablePlugins(PlayJava)
   .disablePlugins(PlayLogback)
+  .settings(Common.settings: _*)
   .settings(
-
-    name := "scene-server",
-    version := "1.0.0",
-    organization := "br.ufes.inf.lprm",
-
-    crossPaths := false,
-
     libraryDependencies ++= Seq(javaCore, filters),
-
     routesGenerator := InjectedRoutesGenerator
-  ).dependsOn(`scene-core`)
-
+  ).dependsOn(core)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,0 +1,7 @@
+import sbt._
+import Keys._
+
+object SceneBuild extends Build {
+  import Dependencies._
+  val ProjectPrefix = "scene-"
+}

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,0 +1,14 @@
+import sbt._
+import Keys._
+
+object Common {
+
+  val mavenRepo = Some("Maven" at "https://mymavenrepo.com/repo/PkZASKyCrrcPaIvQ1RtQ/")
+
+  val settings: Seq[Def.Setting[_]] = Seq(
+    organization := "br.ufes.inf.lprm",
+    crossPaths := false,
+    autoScalaLibrary := false,
+    scalaVersion := "2.11.7"
+  )
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,43 @@
+import sbt._
+import Keys._
+
+object Dependencies {
+
+  val `junit-version`       = "4.8.1"
+  val `slf4j-version`       = "1.7.21"
+  val `drools-version`      = "6.5.0.Final"
+  val `reflections-version` = "0.9.10"
+  val `joda-time-version`   = "2.3"
+  val `gson-version`        = "2.7"
+
+  val junit             = "junit" % "junit" % `junit-version`
+  val `slf4j-log4j12`   = "org.slf4j" % "slf4j-api" % `slf4j-version`
+  val `slf4j-api`       = "org.slf4j" % "slf4j-api" % `slf4j-version`
+  val `drools-compiler` = "org.drools" % "drools-compiler" % `drools-version`
+  val `drools-core`     = "org.drools" % "drools-core" % `drools-version`
+  val `kie-api`         = "org.kie" % "kie-api" % `drools-version`
+  val `reflections`     = "org.reflections" % "reflections" % `reflections-version`
+  val gson              = "com.google.code.gson" % "gson" % `gson-version`
+  val `joda-time`       = "joda-time" % "joda-time" % `joda-time-version`
+
+  val commonDependencies: Seq[ModuleID] = Seq(
+    junit,
+    `slf4j-log4j12`
+  )
+
+  val droolsDependencies: Seq[ModuleID] = Seq(
+    `drools-compiler`,
+    `drools-core`,
+    `kie-api`
+  )
+
+  val modelDependencies: Seq[ModuleID] = commonDependencies ++ Seq(
+    `joda-time`
+  )
+
+  val coreDependencies: Seq[ModuleID] = commonDependencies ++ droolsDependencies ++ Seq(
+    gson,
+    reflections
+  )
+
+}


### PR DESCRIPTION
Reorganizing the project build configuration with common settings, dependencies and resolvers in its own files, and being included in each submodule when needed.

