### PR TITLE
Fix `slf4j-log4j12` dependency inclusion

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,14 +4,14 @@ import Keys._
 object Dependencies {
 
   val `junit-version`       = "4.8.1"
-  val `slf4j-version`       = "1.7.21"
+  val `slf4j-version`       = "1.7.22"
   val `drools-version`      = "6.5.0.Final"
   val `reflections-version` = "0.9.10"
   val `joda-time-version`   = "2.3"
   val `gson-version`        = "2.7"
 
   val junit             = "junit" % "junit" % `junit-version`
-  val `slf4j-log4j12`   = "org.slf4j" % "slf4j-api" % `slf4j-version`
+  val `slf4j-log4j12`   = "org.slf4j" % "slf4j-log4j12" % `slf4j-version`
   val `slf4j-api`       = "org.slf4j" % "slf4j-api" % `slf4j-version`
   val `drools-compiler` = "org.drools" % "drools-compiler" % `drools-version`
   val `drools-core`     = "org.drools" % "drools-core" % `drools-version`


### PR DESCRIPTION
Fix the typo in _slf4j_ dependency and also update the version.

The **slf4j-log4j12** dependency was missing and thus the scene logger wasn't working.

> SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
> SLF4J: Defaulting to no-operation (NOP) logger implementationSLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
