### PR TITLE
Fix a bug in the snapshoting process for non-primitive properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Slack Status](https://pextraslack.herokuapp.com/badge.svg)](https://pextraslack.herokuapp.com/)
 [![Travis Status](https://travis-ci.org/pextralabs/scene-platform.svg?branch=development)](https://travis-ci.org/pextralabs/scene-platform)
-![core](https://img.shields.io/badge/core-0.10.1-a295d6.svg)
+![core](https://img.shields.io/badge/core-0.10.2-a295d6.svg)
 ![model](https://img.shields.io/badge/model-0.10.0-f0ad4e.svg)
 
 *SCENE* is a platform for situation management that leverages on [**JBoss Drools**](https://github.com/droolsjbpm/drools) rule engine and its integrated Complex Event Processing features to natively support rule-based situation-awareness.
@@ -36,3 +36,24 @@ In order to fully describe a SCENE situation, one must declare a **`Situation ki
 
 ### Features
 **SCENE** offers a mean to describe situation patterns with features like **generalization**, **composability**, **aggregation** and **temporal correlation** over situations.
+
+### Instalation
+
+#### Maven
+
+```xml
+<repositories>
+	...
+	<repository>
+		<id>Scene repo</id>
+		<url>https://mymavenrepo.com/repo/BG5Za6vz3CyY7SaQjMOa/</url>
+	</repository>
+</repositories>```
+
+```xml
+<dependency>
+	<groupId>br.ufes.inf.lprm</groupId>
+	<artifactId>scene-core</artifactId>
+	<version>0.10.2</version>
+</dependency>
+```

--- a/build.sbt
+++ b/build.sbt
@@ -17,13 +17,15 @@ resolvers in Global ++= Seq(Resolver.mavenLocal,
 lazy val model = ProjectDef("situation-model", "0.10.0").
                     settings(Common.settings: _*).
                     settings(
+                      autoScalaLibrary := false,
                       libraryDependencies ++= Dependencies.modelDependencies,
                       publishTo := Common.mavenRepo
                     ).dependsOn()
 
-lazy val core = ProjectDef("scene-core", "0.10.1")
+lazy val core = ProjectDef("scene-core", "0.10.2")
                         .settings(Common.settings: _*)
                         .settings(
+                          autoScalaLibrary := false,
                           libraryDependencies ++= Dependencies.coreDependencies,
                           isSnapshot := true,
                           publishTo := Common.mavenRepo
@@ -38,6 +40,7 @@ lazy val server = ProjectDef("scene-server", "0.1.0")
   .disablePlugins(PlayLogback)
   .settings(Common.settings: _*)
   .settings(
+    autoScalaLibrary := false,
     libraryDependencies ++= Seq(javaCore, filters),
     routesGenerator := InjectedRoutesGenerator
   ).dependsOn(core)

--- a/scene-core/src/main/java/br/ufes/inf/lprm/scene/model/Snapshot.java
+++ b/scene-core/src/main/java/br/ufes/inf/lprm/scene/model/Snapshot.java
@@ -99,7 +99,7 @@ public class Snapshot implements br.ufes.inf.lprm.situation.model.bindings.Snaps
             if (policy == SnapshotPolicy.Shallow) {
                 for (Field subfield: fields) {
                     subfield.setAccessible(true);
-                    subfield.set(copy, field.get(src));
+                    subfield.set(copy, subfield.get(src));
                     subfield.setAccessible(false);
                 }
                 field.setAccessible(true);

--- a/scene-core/src/main/resources/pom.xml
+++ b/scene-core/src/main/resources/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>br.ufes.inf.lprm</groupId>
 	<artifactId>scene-core</artifactId>
-	<version>2.0.0</version>
+	<version>0.10.2</version>
 	<name>SCENE Core</name>
 	<packaging>jar</packaging>
 </project>

--- a/scene-examples/src/main/java/br/ufes/inf/lprm/scene/examples/fever/FeverExampleMain.java
+++ b/scene-examples/src/main/java/br/ufes/inf/lprm/scene/examples/fever/FeverExampleMain.java
@@ -46,12 +46,12 @@ public class FeverExampleMain {
 
 			p1.setId(1);
 			p1.setName("john");
-			p1.setTemperature(37);
+			p1.getTemperature().setValue(37);
 
 			Person p2 = new Person();
 			p2.setId(2);
 			p2.setName("isaac");
-			p2.setTemperature(37);
+			p2.getTemperature().setValue(37);
 
 			/*Object p1 = factType.newInstance();
 			Object p2 = factType.newInstance();
@@ -74,55 +74,55 @@ public class FeverExampleMain {
 			while (true) {
 				
 				Thread.sleep(1000);
-				p1.setTemperature(38);
-				p2.setTemperature(38);
+				p1.getTemperature().setValue(38);
+				p2.getTemperature().setValue(38);
 				kSession.update(fh1,  p1);
 				kSession.update(fh2,  p2);
 
 				Thread.sleep(3000);
 
-				p1.setTemperature(39);
-				p2.setTemperature(39);
-
-				kSession.update(fh1,  p1);
-				kSession.update(fh2,  p2);
-
-				Thread.sleep(3000);
-
-				p1.setTemperature(40);
-				p2.setTemperature(40);
+				p1.getTemperature().setValue(39);
+				p2.getTemperature().setValue(39);
 
 				kSession.update(fh1,  p1);
 				kSession.update(fh2,  p2);
 
 				Thread.sleep(3000);
 
-				p1.setTemperature(39);
-				p2.setTemperature(39);
+				p1.getTemperature().setValue(40);
+				p2.getTemperature().setValue(40);
 
 				kSession.update(fh1,  p1);
 				kSession.update(fh2,  p2);
 
 				Thread.sleep(3000);
 
-				p1.setTemperature(37);
-				p2.setTemperature(37);
+				p1.getTemperature().setValue(39);
+				p2.getTemperature().setValue(39);
 
 				kSession.update(fh1,  p1);
 				kSession.update(fh2,  p2);
 
 				Thread.sleep(3000);
 
-				p1.setTemperature(32);
-				p2.setTemperature(32);
+				p1.getTemperature().setValue(37);
+				p2.getTemperature().setValue(37);
 
 				kSession.update(fh1,  p1);
 				kSession.update(fh2,  p2);
 
 				Thread.sleep(3000);
 
-				p1.setTemperature(31);
-				p2.setTemperature(31);
+				p1.getTemperature().setValue(32);
+				p2.getTemperature().setValue(32);
+
+				kSession.update(fh1,  p1);
+				kSession.update(fh2,  p2);
+
+				Thread.sleep(3000);
+
+				p1.getTemperature().setValue(31);
+				p2.getTemperature().setValue(31);
 
 				kSession.update(fh1,  p1);
 				kSession.update(fh2,  p2);

--- a/scene-examples/src/main/java/br/ufes/inf/lprm/scene/examples/fever/entities/Person.java
+++ b/scene-examples/src/main/java/br/ufes/inf/lprm/scene/examples/fever/entities/Person.java
@@ -4,7 +4,7 @@ public class Person {
 
     private int id;
     private String name;
-    private int temperature;
+    private Temperature temperature;
 
     public int getId() {
         return id;
@@ -12,6 +12,7 @@ public class Person {
 
     public Person setId(int id) {
         this.id = id;
+        temperature = new Temperature();
         return this;
     }
 
@@ -24,12 +25,8 @@ public class Person {
         return this;
     }
 
-    public int getTemperature() {
+    public Temperature getTemperature() {
         return temperature;
     }
 
-    public Person setTemperature(int temperature) {
-        this.temperature = temperature;
-        return this;
-    }
 }

--- a/scene-examples/src/main/java/br/ufes/inf/lprm/scene/examples/fever/entities/Temperature.java
+++ b/scene-examples/src/main/java/br/ufes/inf/lprm/scene/examples/fever/entities/Temperature.java
@@ -1,0 +1,17 @@
+package br.ufes.inf.lprm.scene.examples.fever.entities;
+
+
+public class Temperature {
+
+    private int value;
+
+    public int getValue() {
+        return value;
+    }
+
+    public Temperature setValue(int value) {
+        this.value = value;
+        return this;
+    }
+
+}

--- a/scene-examples/src/main/resources/br/ufes/inf/lprm/scene/examples/fever/FeverSituation.drl
+++ b/scene-examples/src/main/resources/br/ufes/inf/lprm/scene/examples/fever/FeverSituation.drl
@@ -1,24 +1,25 @@
 package br.ufes.inf.lprm.scene.examples.fever;
 
 import br.ufes.inf.lprm.scene.examples.fever.entities.Person;
+import br.ufes.inf.lprm.scene.examples.fever.entities.Temperature;
 import br.ufes.inf.lprm.scene.examples.fever.situations.NoFever;
 
 import br.ufes.inf.lprm.scene.model.Situation;
 import br.ufes.inf.lprm.situation.bindings.*;
 import br.ufes.inf.lprm.situation.model.Participation;
-import br.ufes.inf.lprm.situation.model.SituationType
+import br.ufes.inf.lprm.situation.model.SituationType;
 import br.ufes.inf.lprm.scene.util.SituationHelper;
 
 declare Fever extends Situation
     febrile: Person @part @key
-    temp: int @snapshot
+    temp: Temperature @snapshot
 end
 
 rule "FeverSituation"
 @role(situation)
 @type(Fever)
     when
-    	febrile: Person(temp: temperature, temperature > 37)
+    	febrile: Person(temp: temperature, temperature.value > 37)
     then
     	SituationHelper.situationDetected(drools);
 end
@@ -27,21 +28,7 @@ rule "NoFeverSituation"
 @role(situation)
 @type(situations.NoFever)
     when
-    	f1: Person(temperature <= 37)
+    	f1: Person(temperature.value <= 37)
     then
     	SituationHelper.situationDetected(drools);
 end
-
-rule Subscription
-    when
-        $situation: Situation(active)
-    then
-        System.out.println($situation.toString());
-end
-
-/*rule "Test"
-    when
-    	$f: Fever()
-    then
-        System.out.println($f.getType().getDeclaredFields());
-end*/


### PR DESCRIPTION
It was copying a subfield but setting it with the owner object. Just needed to change it to get the subfield value from the source object. Otherwise it always gives a `java.lang.IllegalAccessException`.

This PR also includes a change in the Fever example, objectifying/reifying the temperature property into a relation with a `Temperature` class to demonstrate the snapshot now works for non-primitive objects.

Closes #12